### PR TITLE
JS Fehler in replacer.js

### DIFF
--- a/system/modules/font-awesome/assets/replacer-uncompressed.js
+++ b/system/modules/font-awesome/assets/replacer-uncompressed.js
@@ -260,13 +260,15 @@ window.addEvent('domready', function() {
 	{
 		var icon = group.getElement('i');	
 		
-		if(new String(icon.getPrevious('img').get('src')).test('Minus')) {
-			icon.addClass('icon-minus-sign');
-			icon.removeClass('icon-plus-sign');
+		if (icon != undefined) {
+			if(new String(icon.getPrevious('img').get('src')).test('Minus')) {
+				icon.addClass('icon-minus-sign');
+				icon.removeClass('icon-plus-sign');
+			}
+			else {
+				icon.removeClass('icon-minus-sign');
+				icon.addClass('icon-plus-sign');
+			}
 		}
-		else {
-			icon.removeClass('icon-minus-sign');
-			icon.addClass('icon-plus-sign');
-		}		
 	});
 });


### PR DESCRIPTION
Bei mir erscheint andauernd ein JS Fehler in der Konsole.
![screen shot 2013-08-15 at 16 36 56](https://f.cloud.github.com/assets/1264033/969160/3069648c-05b8-11e3-914b-fbeacc977cc0.png)

Um den Fehler zu beheben habe ich die uncompressed Version eingebunden und dort den Fehler behoben. Die Variable `icon` die in 261 erzeugt wird hat keinen Wert. Mit der Überprüfung aus dem Pull Request ist der Fehler behoben.
